### PR TITLE
Omit yamada from sources

### DIFF
--- a/nschecker/source.go
+++ b/nschecker/source.go
@@ -67,16 +67,6 @@ var Sources = []Source{
 		SoldOutText: `<span>完売御礼</span>`,
 	},
 	{
-		Name:        "yamada - Nintendo Switch Joy-Con (L) / (R) グレー",
-		URL:         "http://www.yamada-denkiweb.com/1177991016",
-		SoldOutText: `<button type="submit" class="btn btn-disabled btn-block" disabled="disabled">売り切れました</button>`,
-	},
-	{
-		Name:        "yamada - Nintendo Switch Joy-Con (L) ネオンブルー/ (R) ネオンレッド",
-		URL:         "http://www.yamada-denkiweb.com/1177992013",
-		SoldOutText: `<button type="submit" class="btn btn-disabled btn-block" disabled="disabled">売り切れました</button>`,
-	},
-	{
 		Name:        "toysrus - Nintendo Switch Joy-Con (L) / (R) グレー",
 		URL:         "https://www.toysrus.co.jp/s/dsg-572182200",
 		SoldOutText: `<span id="isStock_c" >在庫なし/入荷予定あり</span>`,


### PR DESCRIPTION
Yamada url is not available.
Yamada has NOT switch sales page now.

![screen shot 2017-06-26 at 20 07 20](https://user-images.githubusercontent.com/828919/27536653-1786e8b2-5aab-11e7-9192-f20fe54ffe43.png)

http://www.yamada-denkiweb.com/1177991016
http://www.yamada-denkiweb.com/1177992013
